### PR TITLE
E884 error fix (Function name cannot contain a colon)

### DIFF
--- a/plugin/git-branch-info.vim
+++ b/plugin/git-branch-info.vim
@@ -153,7 +153,7 @@ endfunction
 " *****************************************************************************
 " functions called from menu
 " *****************************************************************************
-function! <SID>:GitBranchInfoCheckout(branch)
+function! s:GitBranchInfoCheckout(branch)
 	let l:tokens	= GitBranchInfoTokens()
 	let l:checkout	= "git\ checkout\ ".a:branch 
 	let l:where		= substitute(b:gbi_git_dir,".git$","","")
@@ -162,7 +162,7 @@ function! <SID>:GitBranchInfoCheckout(branch)
 	call s:GitBranchInfoRenewMenu(l:tokens[0],l:tokens[1],l:tokens[2])
 endfunction
 
-function! <SID>:GitBranchInfoFetch(remote)
+function! s:GitBranchInfoFetch(remote)
 	let l:tokens	= GitBranchInfoTokens()
 	let l:fetch		=  "git\ fetch\ ".a:remote
 	let l:where		= substitute(b:gbi_git_dir,".git$","","")


### PR DESCRIPTION
I updated vim to 7.4.316 and got next errors:

> line  156:
> E884: Function name cannot contain a colon: :GitBranchInfoCheckout(branch)
> ...
> line  165:
> E884: Function name cannot contain a colon: :GitBranchInfoFetch(remote)

As I understood (http://vim.1045645.n5.nabble.com/lt-SID-gt-or-s-General-questions-about-functions-td4297515.html for example) we do not need <SID> in function declaration.
